### PR TITLE
temperature error code check for zeroerr drives

### DIFF
--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/cia402_common_defs.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/cia402_common_defs.hpp
@@ -24,6 +24,7 @@
 #define CiA402D_TPDO_POSITION ((uint16_t) 0x6064)
 #define CiA402D_TPDO_STATUSWORD  ((uint16_t) 0x6041)
 #define CiA402D_TPDO_MODE_OF_OPERATION_DISPLAY  ((uint16_t) 0x6061)
+#define CiA402D_TPDO_ERROR_CODE  ((uint16_t) 0x603f)
 
 #include <map>
 #include <string>

--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/include/ethercat_generic_plugins/generic_ec_cia402_drive.hpp
@@ -64,6 +64,8 @@ protected:
   int fault_reset_command_interface_index_ = -1;
   bool last_fault_reset_command_ = false;
   double last_position_ = std::numeric_limits<double>::quiet_NaN();
+  bool temperature_fault_detected_ = false;
+  uint16_t error_code_ = 0;
 
   /** returns device state based upon the status_word */
   DeviceState deviceState(uint16_t status_word);

--- a/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
+++ b/ethercat_manager/include/ethercat_manager/ec_master_async_io.hpp
@@ -20,7 +20,7 @@
 #define EC_IOR(nr, type)  _IOR(EC_IOCTL_TYPE, nr, type)
 #define EC_IOW(nr, type)  _IOW(EC_IOCTL_TYPE, nr, type)
 #define EC_IOWR(nr, type)  _IOWR(EC_IOCTL_TYPE, nr, type)
-#define EC_IOCTL_VERSION_MAGIC 31
+#define EC_IOCTL_VERSION_MAGIC 37 // ioctl() version magic is matching: /dev/EtherCAT0: 37, ethercat tool: 37
 #define EC_IOCTL_MODULE  EC_IOR(0x00, ec_ioctl_module_t)
 #define EC_IOCTL_SLAVE_SDO_UPLOAD  EC_IOWR(0x0e, ec_ioctl_slave_sdo_upload_t)
 #define EC_IOCTL_SLAVE_SDO_DOWNLOAD  EC_IOWR(0x0f, ec_ioctl_slave_sdo_download_t)

--- a/ethercat_manager/src/ethercat_sdo_srv_server.cpp
+++ b/ethercat_manager/src/ethercat_sdo_srv_server.cpp
@@ -54,7 +54,7 @@ void upload(
 
   EcMasterAsync master(request->master_id);
   try {
-    master.open(EcMasterAsync::Read);
+    master.open(EcMasterAsync::ReadWrite);
   } catch (MasterException & e) {
     return_stream << e.what();
     response->success = false;


### PR DESCRIPTION
error_code is detected for temperature limit fault. (0x4110)
if temperature limit is reached, stop auto resetting. 

State machine does reset to enable state!


Also changed :  master.open(EcMasterAsync::ReadWrite) instead of  master.open(EcMasterAsync::Read) in ethercat_manager/src/ethercat_sdo_srv_server.cpp, so as to call ros2 service which requests slaves/master using ethercat tools. otherwise permission denied errors comes up. 
   