### PR TITLE
Added limits functionality for command interfaces

### DIFF
--- a/ethercat_driver_ros2/sphinx/user_guide/config_generic_slave.rst
+++ b/ethercat_driver_ros2/sphinx/user_guide/config_generic_slave.rst
@@ -83,6 +83,12 @@ Each PDO Channel has the following configuration flags:
     - Data conversion factor/scale (:code:`type` : :code:`double`).
   * - :code:`offset`
     - Data offset term (:code:`type` : :code:`double`).
+  * - :code:`peak_upper_limit`
+    - Peak Upper limit (:code:`type` : :code:`double`) applied to command_interface as saturation before multiplying factor and adding offset. default value is :code:`6.2831853` (2*PI).
+  * - :code:`peak_lower_limit`
+    - Peak Lower limit (:code:`type` : :code:`double`) applied to command_interface as saturation before multiplying factor and adding offset. default value is :code:`-6.2831853` (-2*PI).
+  * - :code:`peak_limit_multiplier`
+    - Peak limit multiplier (:code:`type` : :code:`double`) applied to peak limits to scale them slightly below the actual actuator limits (specified in peak upper/lower limits). This is useful to avoid hitting the limits during operation.
 
 
 .. warning:: For each channel, tags :code:`index`, :code:`sub_index` and :code:`type` are **mandatory** even if the channel is not used in order to fill the data layout expected by the module. All other tags can remain unset.


### PR DESCRIPTION
1. Updated the ec_pdo_channel_manager.hpp file to incorporate the new limit parameters and apply them to the command interface values before sending them to the actuators.
2. Updated the Sphinx documentation to include descriptions of the new parameters in the configuration guide.
3. Modified the CST versions of the actuator YAML configuration files for the eRob70F, eRob80F, eRob90F, eRob142F and their reverses to include peak_upper_limit, peak_lower_limit, and peak_limit_multiplier parameters for the effort command interface. This change is done in the hmnd repository where this repo is a submodule.
4. Verified changes by running and testing with hardware.