### PR TITLE
[RIM-9] Fix Joint Dropping Issue after Breake Release

### DIFF
--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -91,21 +91,11 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
     if (pdo_channels_info_[index].index == CiA402D_TPDO_POSITION)
     {
         double current_position = pdo_channels_info_[index].last_value;
-        // Initialize last_position_ if it hasn't been set yet (first time)
-        if (std::isnan(last_position_))
+        // Initialize last_position_ if it hasn't been set yet (first time) and the drive is operational
+        if (std::isnan(last_position_) && is_operational_)
         {
             last_position_ = current_position;
             std::cout << "Position initialized: " << last_position_ << std::endl;
-        }
-        else
-        {
-            // Only update last_position_ if the change is significant (prevents drifting)
-            double position_threshold = 0.0001; // Adjust this threshold as needed
-            double change = std::abs(current_position - last_position_);
-            if (change > position_threshold)
-            {
-                last_position_ = current_position;
-            }
         }
     }
 


### PR DESCRIPTION
The fix we found for joint dropping issue at wakeup after brake release does the following:

- Removed the previous else logic (which sets the target position to the current position when the change is larger than a threshold set (a few encoder steps) -- which in fact allowed the dropping behavior with heavy load),
- Added the check whether the slave drive is operational since without it the current position reading is not the real value but only containing the offset, so it triggers another error (velocity limit violation) when the target position is set to the offset values and suddenly set to the real current measured value.

Tested on hardware.