### PR TITLE
use_monotic_instead_of_realtime

### DIFF
--- a/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
+++ b/ethercat_driver/include/ethercat_driver/ethercat_driver.hpp
@@ -83,6 +83,8 @@ private:
     "ethercat_interface", "ethercat_interface::EcSlave"};
 
   int control_frequency_;
+  uint64_t cycle_app_time_ns_{0};
+  bool cycle_app_time_valid_{false};
   std::unique_ptr<ethercat_interface::EcMaster> master_;
   std::mutex ec_mutex_;
   bool activated_;

--- a/ethercat_driver/src/ethercat_driver.cpp
+++ b/ethercat_driver/src/ethercat_driver.cpp
@@ -23,6 +23,16 @@
 
 namespace ethercat_driver
 {
+namespace {
+
+uint64_t monotonicNowNs() {
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  return ethercat_interface::monotonicTimespecToNs(t);
+}
+
+}  // namespace
+
 CallbackReturn EthercatDriver::on_init(
   const hardware_interface::HardwareInfo & info)
 {
@@ -32,6 +42,8 @@ CallbackReturn EthercatDriver::on_init(
 
   const std::lock_guard<std::mutex> lock(ec_mutex_);
   activated_ = false;
+  cycle_app_time_ns_ = 0;
+  cycle_app_time_valid_ = false;
 
   // Parse master_id from hardware parameters
   int master_id = 0;  // Default to 0 if not specified
@@ -338,7 +350,7 @@ CallbackReturn EthercatDriver::on_activate(
     clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &t, NULL);
     // update EtherCAT bus
 
-    master_->update();
+    master_->update(ethercat_interface::monotonicTimespecToNs(t));
     RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "updated!");
 
     // check if operational
@@ -370,6 +382,7 @@ CallbackReturn EthercatDriver::on_deactivate(
 {
   const std::lock_guard<std::mutex> lock(ec_mutex_);
   activated_ = false;
+  cycle_app_time_valid_ = false;
 
   RCLCPP_INFO(rclcpp::get_logger("EthercatDriver"), "Stopping ...please wait...");
 
@@ -392,6 +405,8 @@ hardware_interface::return_type EthercatDriver::read(
   // try to lock so we can avoid blocking the read/write loop on the lock.
   const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
   if (lock.owns_lock() && activated_) {
+    cycle_app_time_ns_ = monotonicNowNs();
+    cycle_app_time_valid_ = true;
     master_->readData();
   }
   return hardware_interface::return_type::OK;
@@ -403,8 +418,9 @@ hardware_interface::return_type EthercatDriver::write(
 {
   // try to lock so we can avoid blocking the read/write loop on the lock.
   const std::unique_lock<std::mutex> lock(ec_mutex_, std::try_to_lock);
-  if (lock.owns_lock() && activated_) {
-    master_->writeData();
+  if (lock.owns_lock() && activated_ && cycle_app_time_valid_) {
+    master_->writeData(cycle_app_time_ns_, 0);
+    cycle_app_time_valid_ = false;
   }
   return hardware_interface::return_type::OK;
 }

--- a/ethercat_interface/include/ethercat_interface/ec_master.hpp
+++ b/ethercat_interface/include/ethercat_interface/ec_master.hpp
@@ -28,6 +28,11 @@
 namespace ethercat_interface
 {
 
+inline uint64_t monotonicTimespecToNs(const timespec & tv)
+{
+  return static_cast<uint64_t>(tv.tv_sec) * 1000000000ULL + static_cast<uint64_t>(tv.tv_nsec);
+}
+
 class EcMaster
 {
 public:
@@ -50,6 +55,7 @@ public:
 
   /** perform one EtherCAT cycle, passing the domain to the slaves */
   virtual void update(uint32_t domain = 0);
+  virtual void update(uint64_t app_time, uint32_t domain);
 
   /** run a control loop of update() and user_callback(), blocking.
    *  call activate and setThreadHighPriority/RealTime first. */
@@ -89,6 +95,7 @@ public:
 
   void readData(uint32_t domain = 0);
   void writeData(uint32_t domain = 0);
+  void writeData(uint64_t app_time, uint32_t domain);
 
   bool isValid() const { return master_ != NULL; }
 

--- a/ethercat_interface/src/ec_master.cpp
+++ b/ethercat_interface/src/ec_master.cpp
@@ -100,7 +100,7 @@ void EcMaster::addSlave(uint16_t alias, uint16_t position, EcSlave * slave)
   if (slave->assign_activate_dc_sync()) {
     struct timespec t;
     clock_gettime(CLOCK_MONOTONIC, &t);
-    ecrt_master_application_time(master_, EC_NEWTIMEVAL2NANO(t));
+    ecrt_master_application_time(master_, monotonicTimespecToNs(t));
     ecrt_slave_config_dc(
       slave_info.config,
       slave->assign_activate_dc_sync(),
@@ -238,7 +238,7 @@ bool EcMaster::activate()
   // set application time
   struct timespec t;
   clock_gettime(CLOCK_MONOTONIC, &t);
-  ecrt_master_application_time(master_, EC_NEWTIMEVAL2NANO(t));
+  ecrt_master_application_time(master_, monotonicTimespecToNs(t));
 
   // activate master
   bool activate_status = ecrt_master_activate(master_);
@@ -263,6 +263,13 @@ bool EcMaster::activate()
 }
 
 void EcMaster::update(uint32_t domain)
+{
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  update(monotonicTimespecToNs(t), domain);
+}
+
+void EcMaster::update(uint64_t app_time, uint32_t domain)
 {
   // receive process data
   ecrt_master_receive(master_);
@@ -290,10 +297,7 @@ void EcMaster::update(uint32_t domain)
     }
   }
 
-  struct timespec t;
-
-  clock_gettime(CLOCK_REALTIME, &t);
-  ecrt_master_application_time(master_, EC_NEWTIMEVAL2NANO(t));
+  ecrt_master_application_time(master_, app_time);
   ecrt_master_sync_reference_clock(master_);
   ecrt_master_sync_slave_clocks(master_);
 
@@ -337,6 +341,13 @@ void EcMaster::readData(uint32_t domain)
 
 void EcMaster::writeData(uint32_t domain)
 {
+  struct timespec t;
+  clock_gettime(CLOCK_MONOTONIC, &t);
+  writeData(monotonicTimespecToNs(t), domain);
+}
+
+void EcMaster::writeData(uint64_t app_time, uint32_t domain)
+{
   DomainInfo * domain_info = domain_info_.at(domain);
   if (domain_info == NULL) {
     throw std::runtime_error("Null domain info: " + std::to_string(domain));
@@ -349,10 +360,7 @@ void EcMaster::writeData(uint32_t domain)
     }
   }
 
-  struct timespec t;
-
-  clock_gettime(CLOCK_REALTIME, &t);
-  ecrt_master_application_time(master_, EC_NEWTIMEVAL2NANO(t));
+  ecrt_master_application_time(master_, app_time);
   ecrt_master_sync_reference_clock(master_);
   ecrt_master_sync_slave_clocks(master_);
 


### PR DESCRIPTION
### TL;DR

Added application time tracking to EtherCAT driver to improve timing synchronization between read/write cycles and EtherCAT master operations.

### What changed?

- Added `cycle_app_time_ns_` and `cycle_app_time_valid_` members to track application timing in the EtherCAT driver
- Introduced `monotonicNowNs()` helper function to get current monotonic time in nanoseconds
- Modified `read()` method to capture and store the current application time
- Updated `write()` method to pass the captured application time to the EtherCAT master
- Added overloaded `update()` and `writeData()` methods in `EcMaster` that accept application time as a parameter
- Replaced `EC_NEWTIMEVAL2NANO` macro with custom `monotonicTimespecToNs()` function for consistent time conversion
- Changed from `CLOCK_REALTIME` to `CLOCK_MONOTONIC` for application time in EtherCAT operations

### How to test?

- Verify that EtherCAT communication continues to work normally with existing slave devices
- Check that timing synchronization between master and slaves remains stable
- Monitor for any timing-related errors or warnings in the EtherCAT logs
- Test with distributed clock (DC) synchronized slaves to ensure proper timing coordination

### Why make this change?

This change improves timing accuracy by ensuring that the EtherCAT master uses the same application time reference that corresponds to when the read operation occurred, rather than generating a new timestamp during write operations. This provides better synchronization between the control cycle timing and EtherCAT communication timing, which is particularly important for applications requiring precise timing coordination.