### PR TITLE
engage_brakes_on_demand

### DIFF
--- a/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
+++ b/ethercat_generic_plugins/ethercat_generic_cia402_drive/src/generic_ec_cia402_drive.cpp
@@ -69,16 +69,20 @@ void EcCiA402Drive::processData(size_t index, uint8_t *domain_address)
             }
             if (auto_state_cmd_index_ >= 0)
             {
-                if (command_interface_ptr_->at(auto_state_cmd_index_) == 0)
+                double cmd = command_interface_ptr_->at(auto_state_cmd_index_);
+                if (!std::isnan(cmd))
                 {
-                    last_auto_state_cmd_ = false;
-                }
-                if (last_auto_state_cmd_ == false &&
-                    command_interface_ptr_->at(auto_state_cmd_index_) != 0 &&
-                    !std::isnan(command_interface_ptr_->at(auto_state_cmd_index_)))
-                {
-                    last_auto_state_cmd_ = true;
-                    auto_state_transitions_cmd_ = true;
+                    // Level-triggered. Non-zero -> release brakes (enable op).
+                    // Zero -> engage brakes (disable op).
+                    if (cmd == 0.0)
+                    {
+                        auto_state_transitions_cmd_ = false;
+                    }
+                    else
+                    {
+                        auto_state_transitions_cmd_ = true;
+                    }
+                    last_auto_state_cmd_ = auto_state_transitions_cmd_;
                 }
             }
         }
@@ -346,7 +350,14 @@ uint16_t EcCiA402Drive::transition(DeviceState state, uint16_t control_word)
         {
             return (control_word & 0b01110111) | 0b00000111;
         }
-    case STATE_OPERATION_ENABLED: // -> GOOD
+    case STATE_OPERATION_ENABLED:
+        // Disable Operation (0x07) -> drops to STATE_SWITCH_ON; existing
+        // else branch above then holds us there. Brake engages, motor stays
+        // powered (faster re-enable).
+        if (!auto_state_transitions_cmd_)
+        {
+            return (control_word & 0b01110111) | 0b00000111;
+        }
         return control_word;
     case STATE_QUICK_STOP_ACTIVE: // -> STATE_OPERATION_ENABLED
         return (control_word & 0b01111111) | 0b00001111;


### PR DESCRIPTION
### TL;DR

Fixes the auto state transition command to be level-triggered instead of edge-triggered, and adds support for transitioning back to `STATE_SWITCH_ON` when the command is de-asserted.

### What changed?

The `auto_state_transitions_cmd_` logic was previously edge-triggered, meaning it would only activate on a rising edge (transition from 0 to non-zero). It has been reworked to be level-triggered, so a non-zero value continuously enables operation and a zero value disables it. NaN values are now ignored rather than treated as a de-assert.

Additionally, when `STATE_OPERATION_ENABLED` is active and `auto_state_transitions_cmd_` is `false`, the drive now issues a Disable Operation command (`0x07`), dropping back to `STATE_SWITCH_ON`. This keeps the motor powered while engaging the brake, allowing for faster re-enable compared to a full shutdown.

### How to test?

1. Configure a drive with `auto_state_transitions` enabled.
2. Assert the command interface with a non-zero value and verify the drive reaches `STATE_OPERATION_ENABLED`.
3. Set the command interface to `0` and verify the drive drops to `STATE_SWITCH_ON` (brake engages, motor remains powered).
4. Re-assert a non-zero value and verify the drive returns to `STATE_OPERATION_ENABLED` promptly.
5. Set the command interface to `NaN` and verify the drive holds its current state without changing.

### Why make this change?

The previous edge-triggered behavior made it impossible to disable operation after it had been enabled without a full re-initialization. Level-triggered control allows the commanding system to dynamically enable and disable the drive by simply holding the command value, which is more intuitive and supports use cases such as brake control during normal operation.